### PR TITLE
feat(analytics): GA4 page view tracking, and fix the 404 redirect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,50 @@
 <html lang="he" dir="rtl">
   <head>
     <meta charset="utf-8" />
+
+    <!--
+      Google tag (gtag.js). Lives here rather than in the bundle so it starts
+      before React parses, as Google recommends. The measurement id is public —
+      it ships in the page source either way — so there is nothing to hide in an
+      environment variable, and hardcoding it keeps the build free of one more
+      setting that can silently go missing.
+    -->
+    <script>
+      (function () {
+        var MEASUREMENT_ID = 'G-9PNRG536DT';
+
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function () {
+          window.dataLayer.push(arguments);
+        };
+
+        // Development runs the same bundle as production, so without this the
+        // reports would be polluted with our own browsing. gtag is still
+        // defined above, which lets the app call it unconditionally.
+        var host = window.location.hostname;
+        var isLocal =
+          host === '' ||
+          host === 'localhost' ||
+          host === '127.0.0.1' ||
+          host === '[::1]' ||
+          host.slice(-10) === '.localhost';
+        if (isLocal) return;
+
+        gtag('js', new Date());
+        // Page views are sent by hand from PageViewTracker: a route change in a
+        // single page app never reloads the document, so gtag would otherwise
+        // only ever see the first one. Leaving send_page_view on as well would
+        // double count the landing page.
+        gtag('config', MEASUREMENT_ID, { send_page_view: false });
+
+        var script = document.createElement('script');
+        script.async = true;
+        script.src =
+          'https://www.googletagmanager.com/gtag/js?id=' + MEASUREMENT_ID;
+        document.head.appendChild(script);
+      })();
+    </script>
+
     <!-- <link rel="icon" href="%PUBLIC_URL%/favicon.ico" /> -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { HomePage } from './pages/HomePage/HomePage';
 import { LoginPage } from './pages/LoginPage/LoginPage';
 import { ProductPreview } from './pages/ProductPreview';
 import { AppHeader } from './cmps/AppHeader/AppHeader';
+import { PageViewTracker } from './cmps/PageViewTracker/PageViewTracker';
 import { Footer } from './cmps/design/Footer';
 import SimpleSnackbar from './cmps/Snackbar/Snackbar';
 import { AdminPage } from './pages/AdminPage/AdminPage';
@@ -63,6 +64,7 @@ function App() {
     <CssBaseline>
       <ThemeProvider theme={customTheme}>
         <BrowserRouter>
+          <PageViewTracker />
           <AppHeader />
           <div className="App">
             <Switch>

--- a/src/cmps/PageViewTracker/PageViewTracker.jsx
+++ b/src/cmps/PageViewTracker/PageViewTracker.jsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { analyticsService } from '../../services/analytics.service';
+
+/**
+ * react-helmet writes the document title inside a requestAnimationFrame, so the
+ * title is still the previous page's at the moment this effect runs. Waiting a
+ * beat lets it land first. A plain timer is used rather than another animation
+ * frame on purpose: frames are not scheduled at all in a background tab, which
+ * would drop the page view of anyone opening the site in one.
+ */
+const TITLE_SETTLE_MS = 100;
+
+/**
+ * Reports every route change to Google Analytics. Renders nothing — it only
+ * needs to sit inside the router to see the location.
+ */
+export function PageViewTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      analyticsService.sendPageView({
+        path: location.pathname + location.search,
+        title: document.title,
+      });
+    }, TITLE_SETTLE_MS);
+
+    return () => clearTimeout(timer);
+  }, [location.pathname, location.search]);
+
+  return null;
+}

--- a/src/services/analytics.service.js
+++ b/src/services/analytics.service.js
@@ -1,0 +1,31 @@
+/**
+ * Thin wrapper around the Google tag (gtag.js).
+ *
+ * The tag itself is loaded by the snippet in public/index.html, which also
+ * defines window.gtag before anything else runs. Nothing here loads a script;
+ * this only sends events, and it is safe to call before gtag.js has finished
+ * downloading — the queue it writes to is replayed once the tag is ready.
+ */
+
+function send(eventName, params) {
+  if (typeof window.gtag !== 'function') return;
+  window.gtag('event', eventName, params);
+}
+
+/**
+ * Announces a page the user reached without a document load. The snippet turns
+ * off the automatic page view for exactly this reason, so every page view in
+ * the reports — including the very first one — comes through here.
+ */
+function sendPageView({ path, title }) {
+  send('page_view', {
+    page_path: path,
+    page_title: title,
+    page_location: window.location.href,
+  });
+}
+
+export const analyticsService = {
+  send,
+  sendPageView,
+};

--- a/src/services/http.service.js
+++ b/src/services/http.service.js
@@ -1,23 +1,31 @@
 import axios from 'axios';
 
 const BASE_URL = process.env.REACT_APP_API_HOST;
+
+// A page usually fires several reads at once, and with the API down they all
+// fail together. Without this latch each one starts its own navigation and the
+// browser aborts the previous, so the visitor pays for three page loads to
+// reach the same place.
+let isLeavingForNotFound = false;
+
 export const httpService = {
   async get(endpoint, query = {}) {
     try {
       const queryStr = Object.keys(query)
         .map((key) => key + '=' + query[key])
         .join('&');
-      const response = await axios
-        .get(`${BASE_URL}${endpoint}?${queryStr}`)
-        .catch((error) => {
-          throw new Error(error);
-        });
+      const response = await axios.get(`${BASE_URL}${endpoint}?${queryStr}`);
       return response.data;
     } catch (error) {
-      if (!window.location.href.includes(404)) {
-        console.log(window.location.replace(window.location.href + '404'));
+      // Every failed read sends the visitor to the 404 page, whether the server
+      // reported the resource missing or never answered at all: with the API
+      // down there is no page left worth showing. The pathname check is what
+      // stops the 404 page's own failing requests from redirecting forever.
+      if (!isLeavingForNotFound && window.location.pathname !== '/404') {
+        isLeavingForNotFound = true;
+        window.location.replace('/404');
       }
-      throw new Error(error);
+      throw error;
     }
   },
   post(endpoint, data) {


### PR DESCRIPTION
## What

Two independent changes.

**GA4 page view tracking.** The Google tag (`gtag.js`, `G-9PNRG536DT`) loads from the document head so it starts before React parses. `PageViewTracker` reports every route change as a `page_view`, since a route change in a single page app never reloads the document and gtag would otherwise record exactly one view per session. The automatic page view is turned off in `config` so the landing page is not counted twice, and the tag is skipped on localhost so development traffic stays out of the reports.

**404 redirect fix.** `httpService.get` appended the string `"404"` to the current URL instead of navigating to `/404`, so a failed GET on `/menu/weekend` left the browser at `/menu/weekend404`. It now navigates to `/404`, with a latch so the several reads a page fires at once do not each start their own navigation.

## Verification

Ran against the production build.

| Scenario | Result |
| --- | --- |
| Initial load | one `page_view`, correct path and title |
| Client-side route change | one `page_view`, no duplicates |
| localhost | tag script not loaded |
| API unreachable | redirect to `/404`, stable, no loop |

Page titles come from `react-helmet`, which writes `document.title` inside a `requestAnimationFrame`; the tracker waits for it, using a timer rather than another animation frame because frames are not scheduled at all in a background tab.

Live delivery to GA4 was not exercised — no test hits were sent to the property. Confirm in Reports → Realtime after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
