### PR TITLE
feat(privacy): privacy policy page and consent mode with a cookie banner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,52 @@
           host.slice(-10) === '.localhost';
         if (isLocal) return;
 
+        // Consent mode, advanced. These defaults must be set before the tag is
+        // configured or they are ignored. Storage is denied only where the law
+        // demands it, and Google resolves the region by IP on its side — the
+        // browser cannot be trusted to place itself. Everyone else is granted,
+        // which keeps the Israeli audience, nearly all of the traffic here,
+        // measured in full rather than modelled.
+        gtag('consent', 'default', {
+          ad_storage: 'denied',
+          ad_user_data: 'denied',
+          ad_personalization: 'denied',
+          analytics_storage: 'denied',
+          region: [
+            'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR',
+            'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL',
+            'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'IS', 'LI', 'NO',
+            'GB',
+          ],
+        });
+        gtag('consent', 'default', {
+          ad_storage: 'granted',
+          ad_user_data: 'granted',
+          ad_personalization: 'granted',
+          analytics_storage: 'granted',
+        });
+
+        // A returning visitor already answered the banner, so their choice is
+        // restored here rather than waiting for React to mount. Reading it now
+        // is what makes wait_for_update unnecessary: the update lands before
+        // the tag below has even been requested, so no hit is sent under the
+        // wrong assumption. localStorage throws in Safari's private mode, and
+        // an unreadable choice simply means we ask again.
+        var consent = null;
+        try {
+          consent = window.localStorage.getItem('cg-consent');
+        } catch (error) {
+          consent = null;
+        }
+        if (consent === 'granted' || consent === 'denied') {
+          gtag('consent', 'update', {
+            ad_storage: consent,
+            ad_user_data: consent,
+            ad_personalization: consent,
+            analytics_storage: consent,
+          });
+        }
+
         gtag('js', new Date());
         // Page views are sent by hand from PageViewTracker: a route change in a
         // single page app never reloads the document, so gtag would otherwise

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { LoginPage } from './pages/LoginPage/LoginPage';
 import { ProductPreview } from './pages/ProductPreview';
 import { AppHeader } from './cmps/AppHeader/AppHeader';
 import { PageViewTracker } from './cmps/PageViewTracker/PageViewTracker';
+import { ConsentBanner } from './cmps/ConsentBanner/ConsentBanner';
 import { Footer } from './cmps/design/Footer';
 import SimpleSnackbar from './cmps/Snackbar/Snackbar';
 import { AdminPage } from './pages/AdminPage/AdminPage';
@@ -125,6 +126,7 @@ function App() {
           </div>
           <Footer />
           <SimpleSnackbar></SimpleSnackbar>
+          <ConsentBanner />
         </BrowserRouter>
       </ThemeProvider>
     </CssBaseline>

--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ import getCustomTheme from './hooks/getCustomTheme';
 import Loadable from 'react-loadable';
 import CircularProgress from '@mui/material/CircularProgress';
 import { AccessibilityAnnouncement } from './pages/AccessibilityAnnouncement';
+import { PrivacyPolicy } from './pages/PrivacyPolicy';
 import { NotFound } from './pages/NotFound';
 import { NotEnable } from './pages/NotEnable';
 const customTheme = getCustomTheme();
@@ -112,6 +113,9 @@ function App() {
               </Route>
               <Route exact path="/AccessibilityAnnouncement">
                 <AccessibilityAnnouncement />
+              </Route>
+              <Route exact path="/privacy">
+                <PrivacyPolicy />
               </Route>
 
               <Route path="*">

--- a/src/cmps/AppHeader/AppHeader.jsx
+++ b/src/cmps/AppHeader/AppHeader.jsx
@@ -37,6 +37,7 @@ const NAV_LINKS = [
 
 const MOBILE_EXTRA_LINKS = [
   { to: '/AccessibilityAnnouncement', label: 'הצהרת נגישות' },
+  { to: '/privacy', label: 'מדיניות פרטיות' },
 ];
 
 /**

--- a/src/cmps/ConsentBanner/ConsentBanner.jsx
+++ b/src/cmps/ConsentBanner/ConsentBanner.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { Button, Link, Paper, Stack, Typography } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { consentService } from '../../services/consent.service';
+
+/**
+ * Asks visitors covered by European privacy law whether they accept analytics
+ * cookies. Everyone else never sees it — see consent.service for who is asked
+ * and why enforcement does not depend on that guess.
+ */
+export function ConsentBanner() {
+  // Read once on mount: the answer cannot change until the visitor gives one.
+  const [isAsking, setIsAsking] = useState(() => consentService.shouldAsk());
+
+  if (!isAsking) return null;
+
+  const answer = (decision) => {
+    consentService.decide(decision);
+    setIsAsking(false);
+  };
+
+  return (
+    <Paper
+      role="region"
+      aria-label="הסכמה לשימוש בעוגיות"
+      elevation={8}
+      square
+      sx={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        p: 2,
+        zIndex: (theme) => theme.zIndex.snackbar - 1,
+      }}
+    >
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        justifyContent="center"
+        sx={{ maxWidth: 900, mx: 'auto' }}
+      >
+        <Typography variant="body2" sx={{ flex: 1 }}>
+          אנחנו משתמשים בעוגיות כדי להבין איך גולשים משתמשים באתר ולשפר אותו.
+          דחייה לא משפיעה על הגלישה ולא על ביצוע הזמנות. פרטים נוספים ב
+          <Link component={RouterLink} to="/privacy" underline="always">
+            מדיניות הפרטיות
+          </Link>
+          .
+        </Typography>
+        <Stack direction="row" spacing={1} justifyContent="center">
+          <Button variant="outlined" onClick={() => answer('denied')}>
+            דחייה
+          </Button>
+          <Button variant="contained" onClick={() => answer('granted')}>
+            אישור
+          </Button>
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/cmps/design/Footer/Footer.jsx
+++ b/src/cmps/design/Footer/Footer.jsx
@@ -12,6 +12,7 @@ const INFO_LINKS = [
   { to: '/about', label: 'עלינו' },
   { to: '/contact', label: 'צור קשר' },
   { to: '/AccessibilityAnnouncement', label: 'הצהרת נגישות' },
+  { to: '/privacy', label: 'מדיניות פרטיות' },
 ];
 
 const useStyles = makeStyles({

--- a/src/pages/PrivacyPolicy/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy/PrivacyPolicy.jsx
@@ -1,0 +1,309 @@
+import React from 'react';
+import { makeStyles } from '@mui/styles';
+import { Helmet } from 'react-helmet';
+import { BUSINESS } from '../../cmps/AppHeader/AppHeader';
+import { colors, fonts, radii, shadows } from '../../styles/designTokens';
+
+/**
+ * Every factual claim here is traceable to the code, so nothing invented
+ * reaches a real customer:
+ *   collected fields -> UserDetailsForm.jsx (initialFValues)
+ *   order storage    -> cg-backend models/order.js
+ *   order email      -> cg-backend services/email.service.js (PDF attachment)
+ *   analytics        -> public/index.html, consent.service.js
+ *   browser storage  -> storageService / async-storage.service (sessionStorage)
+ *   contact details  -> BUSINESS in AppHeader.jsx
+ */
+const LAST_UPDATED = 'אוגוסט 2026';
+
+const useStyles = makeStyles({
+  page: {
+    background: colors.bg,
+    padding: '36px 0 64px',
+  },
+  container: {
+    maxWidth: 940,
+    margin: '0 auto',
+    padding: '0 22px',
+  },
+  card: {
+    background: colors.surface,
+    border: `1px solid ${colors.border}`,
+    borderRadius: radii.xl,
+    boxShadow: shadows.cardSoft,
+    padding: '46px 48px 50px',
+    '@media (max-width:640px)': { padding: '30px 20px 34px' },
+  },
+  title: {
+    fontFamily: fonts.display,
+    fontWeight: 400,
+    fontSize: 'clamp(25px,4.4vw,38px)',
+    lineHeight: 1.3,
+    color: colors.text,
+    margin: '0 0 12px',
+  },
+  updated: {
+    fontSize: 15,
+    color: colors.textMuted,
+    margin: '0 0 26px',
+    paddingBottom: 24,
+    borderBottom: `1px solid ${colors.border}`,
+  },
+  section: {
+    fontFamily: fonts.display,
+    fontWeight: 400,
+    fontSize: 'clamp(20px,3.2vw,27px)',
+    lineHeight: 1.35,
+    color: colors.greenInk,
+    margin: '40px 0 16px',
+  },
+  prose: {
+    fontSize: 17,
+    lineHeight: 1.85,
+    color: colors.textSoft,
+    maxWidth: '70ch',
+    margin: '0 0 18px',
+  },
+  list: {
+    listStyle: 'none',
+    margin: '0 0 24px',
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 10,
+    '& li': {
+      position: 'relative',
+      paddingInlineStart: 26,
+      maxWidth: '70ch',
+      fontSize: 17,
+      lineHeight: 1.75,
+      color: colors.textSoft,
+    },
+    '& li::before': {
+      content: '""',
+      position: 'absolute',
+      insetInlineStart: 6,
+      top: 12,
+      width: 7,
+      height: 7,
+      borderRadius: '50%',
+      background: colors.green,
+    },
+  },
+  link: {
+    color: colors.greenLink,
+    textUnderlineOffset: 3,
+  },
+});
+
+export const PrivacyPolicy = () => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <Helmet>
+        <title>קייטרינג גבאי - מדיניות פרטיות</title>
+        <meta
+          name="description"
+          content="מדיניות הפרטיות של אתר קייטרינג גבאי: איזה מידע נאסף, לשם מה, עם מי הוא משותף וכיצד ניתן לממש את זכויותיכם."
+        />
+        <meta name="robots" content="all" />
+      </Helmet>
+
+      <main className={classes.page}>
+        <div className={`${classes.container} gb-pad`}>
+          <article className={classes.card}>
+            <h1 className={classes.title}>מדיניות פרטיות</h1>
+            <p className={classes.updated}>עודכן לאחרונה: {LAST_UPDATED}</p>
+
+            <p className={classes.prose}>
+              קייטרינג גבאי בע״מ מכבדת את פרטיותכם. מסמך זה מסביר איזה מידע אישי נאסף
+              באתר, כיצד הוא נאסף, לשם מה הוא משמש, עם מי הוא משותף, וכיצד תוכלו
+              לממש את זכויותיכם ביחס אליו. המדיניות מנוסחת בלשון זכר מטעמי נוחות
+              בלבד ומתייחסת לכל המגדרים.
+            </p>
+
+            <h2 className={classes.section}>איזה מידע אנחנו אוספים</h2>
+
+            <p className={classes.prose}>
+              מידע שאתם מוסרים לנו ביוזמתכם, בעת ביצוע הזמנה או פנייה אלינו:
+            </p>
+            <ul className={classes.list}>
+              <li>שם פרטי ושם משפחה.</li>
+              <li>מספר טלפון, ובאפשרותכם להוסיף מספר טלפון נוסף.</li>
+              <li>כתובת דואר אלקטרוני.</li>
+              <li>עיר ורחוב.</li>
+              <li>מספר תעודת זהות.</li>
+              <li>מועד האיסוף ושעת האיסוף שבחרתם.</li>
+              <li>תוכן ההזמנה: המנות, הכמויות והערות שצירפתם.</li>
+            </ul>
+
+            <p className={classes.prose}>
+              מידע הנאסף באופן אוטומטי בעת הגלישה, באמצעות שירותי מדידה: כתובת
+              IP, סוג המכשיר והדפדפן, העמודים שבהם ביקרתם, משך השהייה והאתר שממנו
+              הגעתם. מידע זה נאסף בכפוף להסכמתכם, במקומות שבהם החוק מחייב זאת.
+            </p>
+
+            <p className={classes.prose}>
+              באתר לא מתבצעת סליקה ולא מתבצע תשלום מקוון, ולפיכך איננו אוספים
+              ואיננו שומרים פרטי כרטיס אשראי או פרטי חשבון בנק.
+            </p>
+
+            <h2 className={classes.section}>כיצד המידע נאסף</h2>
+            <ul className={classes.list}>
+              <li>טופס ההזמנה באתר, בעת השלמת ההזמנה.</li>
+              <li>טופס יצירת הקשר ופניות שמגיעות אלינו בדואר אלקטרוני.</li>
+              <li>שיחות טלפון למעדנייה.</li>
+              <li>
+                כלי מדידה וניתוח תנועה המוטמעים באתר, כמתואר בסעיף העוגיות שלהלן.
+              </li>
+            </ul>
+
+            <h2 className={classes.section}>לשם מה אנחנו אוספים את המידע</h2>
+            <ul className={classes.list}>
+              <li>קבלת ההזמנה, הכנתה ומסירתה במועד ובשעה שבחרתם.</li>
+              <li>יצירת קשר בנוגע להזמנה, לרבות עדכונים, בירורים ושינויים.</li>
+              <li>זיהוי המזמין והפקת מסמכי ההזמנה.</li>
+              <li>
+                עמידה בחובות החלות עלינו בדין, ובכלל זה חובות הנהלת חשבונות
+                ושמירת מסמכים.
+              </li>
+              <li>
+                שיפור האתר, התפריט והשירות, על בסיס נתונים סטטיסטיים על אופן
+                השימוש באתר.
+              </li>
+              <li>
+                משלוח עדכונים ומבצעים, ככל שהסכמתם לכך, ובכפוף לזכותכם לחזור בכם
+                בכל עת.
+              </li>
+            </ul>
+
+            <h2 className={classes.section}>
+              כיצד המידע נשמר, משותף ונמסר לאחרים
+            </h2>
+
+            <p className={classes.prose}>
+              פרטי ההזמנה נשמרים במסד הנתונים של האתר, ובנוסף נשלחים אלינו בדואר
+              אלקטרוני בצירוף מסמך ההזמנה. הגישה למידע מוגבלת לבעלי תפקידים
+              במעדנייה הזקוקים לו לצורך מילוי ההזמנה, והכניסה לממשק הניהול מוגנת
+              בהזדהות.
+            </p>
+
+            <p className={classes.prose}>
+              איננו מוכרים מידע אישי ואיננו מעבירים אותו לצדדים שלישיים לצורכי
+              פרסום. לצורך הפעלת האתר אנו נעזרים בספקי שירות, שלכל אחד מהם מדיניות
+              פרטיות משלו:
+            </p>
+            <ul className={classes.list}>
+              <li>Microsoft Azure — אחסון האתר והגשתו לגולשים.</li>
+              <li>Google — שירותי מדידה, מפות ומשלוח הודעות הדואר האלקטרוני.</li>
+              <li>Cloudinary — אחסון והגשה של תמונות המנות.</li>
+              <li>Auth0 — שירות ההזדהות של ממשק הניהול.</li>
+            </ul>
+
+            <p className={classes.prose}>
+              נמסור מידע אישי מעבר לאמור אם נידרש לכך על פי דין, על פי צו של רשות
+              מוסמכת, או לשם הגנה על זכויותינו בהליך משפטי.
+            </p>
+
+            <p className={classes.prose}>
+              המידע נשמר כל עוד הוא דרוש לצרכים שלשמם נאסף, ולתקופות נוספות ככל
+              שאלה נדרשות לפי חובות שמירת מסמכים החלות עלינו בדין.
+            </p>
+
+            <h2 className={classes.section}>כיצד אנחנו יוצרים איתכם קשר</h2>
+            <p className={classes.prose}>
+              אנו פונים אליכם בטלפון או בדואר אלקטרוני, בעיקר בנוגע להזמנה
+              שביצעתם. אם הסכמתם לקבל עדכונים שיווקיים, נוכל לשלוח לכם הודעות על
+              תפריטים ומבצעים. בכל הודעה כזו תימצא דרך פשוטה להסיר את עצמכם
+              מהרשימה, ותוכלו גם לפנות אלינו ישירות בבקשה להפסיק את הדיוור.
+            </p>
+
+            <h2 className={classes.section}>עוגיות וכלי מעקב</h2>
+
+            <p className={classes.prose}>
+              האתר עושה שימוש בעוגיות ובאחסון מקומי בדפדפן לצרכים אלה:
+            </p>
+            <ul className={classes.list}>
+              <li>
+                שמירת עגלת הקניות ופרטי ההזמנה במהלך הגלישה, כדי שלא יאבדו בין
+                העמודים. מידע זה נשמר בדפדפן שלכם בלבד ונמחק עם סגירת החלון.
+              </li>
+              <li>
+                שמירת בחירתכם לגבי עוגיות, כדי שלא נשאל אתכם שוב בכל ביקור.
+              </li>
+              <li>
+                Google Analytics, לצורך הבנת אופן השימוש באתר במונחים סטטיסטיים.
+              </li>
+              <li>Google Maps, בעמודים המציגים מפה.</li>
+            </ul>
+
+            <p className={classes.prose}>
+              עוגיות המדידה פועלות במנגנון ההסכמה של גוגל. במדינות שבהן הדין
+              מחייב הסכמה מוקדמת, האחסון חסום כברירת מחדל עד שתאשרו אותו בבאנר
+              המופיע באתר. תוכלו לעיין במדיניות הפרטיות של גוגל בכתובת{' '}
+              <a
+                className={classes.link}
+                href="https://policies.google.com/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                policies.google.com/privacy
+              </a>
+              .
+            </p>
+
+            <h2 className={classes.section}>
+              זכויותיכם וכיצד לחזור בכם מהסכמה
+            </h2>
+
+            <p className={classes.prose}>
+              על פי חוק הגנת הפרטיות, התשמ״א-1981, אתם רשאים לעיין במידע שנאסף
+              עליכם, לבקש לתקן מידע שאינו נכון, שלם או מדויק, ולבקש את מחיקתו.
+              גולשים המצויים באזור הכלכלי האירופי או בבריטניה זכאים בנוסף לזכויות
+              המוקנות להם לפי ה-GDPR, ובכללן קבלת עותק מהמידע והתנגדות לעיבודו.
+            </p>
+
+            <p className={classes.prose}>
+              למימוש כל אחת מהזכויות האלה פנו אלינו בפרטים שבסוף עמוד זה. בנוסף,
+              תוכלו בכל עת למחוק את העוגיות ואת האחסון המקומי דרך הגדרות הדפדפן —
+              פעולה זו תמחק גם את בחירתכם הקודמת, והבאנר יופיע שוב בביקור הבא.
+            </p>
+
+            <h2 className={classes.section}>שינויים במדיניות</h2>
+            <p className={classes.prose}>
+              אנו רשאים לעדכן מדיניות זו מעת לעת, למשל בעקבות שינוי בשירותים
+              שאנו מציעים או בדרישות הדין. הנוסח המעודכן יפורסם בעמוד זה, ותאריך
+              העדכון האחרון המופיע בראשו ישקף את מועד השינוי. אנו ממליצים לעיין
+              בעמוד זה מדי פעם.
+            </p>
+
+            <h2 className={classes.section}>שאלות ויצירת קשר</h2>
+            <p className={classes.prose}>
+              לכל שאלה בנוגע למדיניות זו, או לבקשה לעיין במידע שנאסף עליכם, לתקן
+              אותו או למחוק אותו, אנחנו זמינים עבורכם:
+            </p>
+            <ul className={classes.list}>
+              <li>
+                טלפון:{' '}
+                <a className={classes.link} href={BUSINESS.phoneHref}>
+                  {BUSINESS.phoneDisplay}
+                </a>
+              </li>
+              <li>
+                דואר אלקטרוני:{' '}
+                <a
+                  className={classes.link}
+                  href={`mailto:${BUSINESS.email}`}
+                >
+                  {BUSINESS.email}
+                </a>
+              </li>
+              <li>כתובת: {BUSINESS.address}</li>
+            </ul>
+          </article>
+        </div>
+      </main>
+    </>
+  );
+};

--- a/src/pages/PrivacyPolicy/index.js
+++ b/src/pages/PrivacyPolicy/index.js
@@ -1,0 +1,1 @@
+export { PrivacyPolicy } from './PrivacyPolicy';

--- a/src/services/consent.service.js
+++ b/src/services/consent.service.js
@@ -1,0 +1,112 @@
+/**
+ * Stores the visitor's cookie decision and reports it to the Google tag.
+ *
+ * The tag snippet in public/index.html sets the defaults and restores a saved
+ * decision before the tag loads; this module owns everything from the moment
+ * the banner appears onwards. Both read the same key, and the stored value is
+ * deliberately just 'granted' or 'denied' so the two can never drift.
+ */
+
+const STORAGE_KEY = 'cg-consent';
+
+/**
+ * Which visitors are *shown* the banner. Enforcement is a separate matter and
+ * belongs to Google, which denies storage by IP geolocation through the region
+ * list in the snippet — something a browser cannot determine for itself.
+ *
+ * That split is what makes a wrong guess here harmless in both directions: a
+ * European we fail to recognise stays denied, and an Israeli we ask needlessly
+ * sees one extra prompt. The zones are the EEA plus the United Kingdom.
+ */
+const CONSENT_REQUIRED_TIME_ZONES = [
+  'Africa/Ceuta',
+  'Asia/Famagusta',
+  'Asia/Nicosia',
+  'Atlantic/Azores',
+  'Atlantic/Canary',
+  'Atlantic/Madeira',
+  'Atlantic/Reykjavik',
+  'Europe/Amsterdam',
+  'Europe/Athens',
+  'Europe/Berlin',
+  'Europe/Bratislava',
+  'Europe/Brussels',
+  'Europe/Bucharest',
+  'Europe/Budapest',
+  'Europe/Busingen',
+  'Europe/Copenhagen',
+  'Europe/Dublin',
+  'Europe/Helsinki',
+  'Europe/Lisbon',
+  'Europe/Ljubljana',
+  'Europe/London',
+  'Europe/Luxembourg',
+  'Europe/Madrid',
+  'Europe/Malta',
+  'Europe/Oslo',
+  'Europe/Paris',
+  'Europe/Prague',
+  'Europe/Riga',
+  'Europe/Rome',
+  'Europe/Sofia',
+  'Europe/Stockholm',
+  'Europe/Tallinn',
+  'Europe/Vaduz',
+  'Europe/Vienna',
+  'Europe/Vilnius',
+  'Europe/Warsaw',
+  'Europe/Zagreb',
+];
+
+function readDecision() {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored === 'granted' || stored === 'denied' ? stored : null;
+  } catch (error) {
+    // Safari in private mode throws rather than returning null.
+    return null;
+  }
+}
+
+function isConsentRequired() {
+  try {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return CONSENT_REQUIRED_TIME_ZONES.indexOf(timeZone) !== -1;
+  } catch (error) {
+    // Without a readable time zone we cannot place the visitor. Staying quiet
+    // leaves them on the defaults, which is the safe half of the trade: a
+    // European keeps their storage denied, they just cannot lift it.
+    return false;
+  }
+}
+
+function shouldAsk() {
+  return !readDecision() && isConsentRequired();
+}
+
+/**
+ * Records the answer and tells the tag about it. Saving first means a browser
+ * that refuses storage still gets the tag updated for the rest of the visit.
+ */
+function decide(decision) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, decision);
+  } catch (error) {
+    // Nothing to do — the banner will simply ask again next time.
+  }
+
+  if (typeof window.gtag !== 'function') return;
+  window.gtag('consent', 'update', {
+    ad_storage: decision,
+    ad_user_data: decision,
+    ad_personalization: decision,
+    analytics_storage: decision,
+  });
+}
+
+export const consentService = {
+  readDecision,
+  isConsentRequired,
+  shouldAsk,
+  decide,
+};


### PR DESCRIPTION
## What

**Privacy policy page** at `/privacy`, following the nine sections Wix recommends: what is collected, how, why, how it is stored and shared, how we contact visitors, cookies, how to withdraw consent, updates, and contact details. Every factual claim is traceable to the code rather than boilerplate — collected fields from `UserDetailsForm`, the storage and mail path from the backend order model and email service, the third parties from the deploy workflow and the analytics snippet, contact details from `BUSINESS`. Linked from the footer, the mobile menu and the consent banner.

**Consent mode (advanced)** with a Hebrew cookie banner. Defaults are set before the tag is configured, as Google requires. Storage is denied by default only in the EEA and the UK via the `region` parameter, so the Israeli audience — nearly all of the traffic — stays measured in full rather than modelled.

The two are one feature in practice: the banner needs a policy to link to, which is why the policy lands first.

## Design note

Google resolves the region by IP on its side. The time zone list in `consent.service` only decides who is *shown* the banner, which makes a wrong guess harmless in both directions: a European we fail to recognise stays denied, and an Israeli asked needlessly sees one extra prompt.

A returning visitor's answer is restored from `localStorage` inside the snippet rather than after React mounts, so the update lands before the tag is even requested and `wait_for_update` is unnecessary.

## Verification

Ran against the production build.

| Scenario | Result |
| --- | --- |
| EEA visitor, no decision yet | banner shown |
| "אישור" | `localStorage='granted'`, banner gone, `consent update` with all four parameters |
| "דחייה" | same, with `denied` |
| Reload after deciding | banner does not return |
| Israeli visitor | banner never shown |
| Banner link | navigates to `/privacy`, banner stays so the visitor can read then decide |
| `/privacy` | renders, all nine sections present, footer link works |

Execution order in the built HTML, which is the part the Google guide is strict about:

```
1  consent","default"   <- EEA denied
2  consent","default"   <- everyone else granted
3  localStorage.getItem("cg-consent")
4  consent","update"    <- restore previous answer
5  "js",new Date
6  "config",a
7  googletagmanager.com/gtag/js
```

The EEA path was exercised by temporarily adding `Asia/Jerusalem` to the time zone list, then reverting and rebuilding.

## Not verified

No test hits were sent to the GA4 property, so live consent signals should be confirmed in Realtime after deploy.

## Follow-ups for a human

- The policy is factually accurate but has not had legal review.
- The order form collects an Israeli ID number (`idPersonal`). Collecting it without a genuine need is hard to justify for a pickup order, and removing the field would shrink both the exposure and what the policy has to defend.
- `text/terms.js` treats supplying contact details as consent to marketing, which is a weaker basis than the explicit opt-in the Israeli anti-spam law expects.
- The retention period is stated in general terms rather than a concrete number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
