### PR TITLE
fix(consent): show the cookie banner to every visitor

### DIFF
--- a/src/cmps/ConsentBanner/ConsentBanner.jsx
+++ b/src/cmps/ConsentBanner/ConsentBanner.jsx
@@ -4,9 +4,9 @@ import { Link as RouterLink } from 'react-router-dom';
 import { consentService } from '../../services/consent.service';
 
 /**
- * Asks visitors covered by European privacy law whether they accept analytics
- * cookies. Everyone else never sees it — see consent.service for who is asked
- * and why enforcement does not depend on that guess.
+ * Asks every visitor whether they accept analytics cookies. What the answer
+ * changes differs by region — see consent.service for why that is settled in
+ * the tag snippet rather than here.
  */
 export function ConsentBanner() {
   // Read once on mount: the answer cannot change until the visitor gives one.

--- a/src/services/consent.service.js
+++ b/src/services/consent.service.js
@@ -5,58 +5,18 @@
  * decision before the tag loads; this module owns everything from the moment
  * the banner appears onwards. Both read the same key, and the stored value is
  * deliberately just 'granted' or 'denied' so the two can never drift.
+ *
+ * Everyone is asked. What the answer *changes* depends on where they are, and
+ * that is decided in the snippet rather than here: in the EEA and the UK
+ * storage starts denied, so the banner is the only way to switch tracking on,
+ * which is the prior opt-in ePrivacy requires. Everywhere else storage starts
+ * granted and the banner is notice plus a genuine way to refuse — the
+ * transparency Israeli law expects. Google resolves which case applies by IP
+ * through the region list, something a browser cannot do for itself, so this
+ * module deliberately makes no attempt to guess the visitor's location.
  */
 
 const STORAGE_KEY = 'cg-consent';
-
-/**
- * Which visitors are *shown* the banner. Enforcement is a separate matter and
- * belongs to Google, which denies storage by IP geolocation through the region
- * list in the snippet — something a browser cannot determine for itself.
- *
- * That split is what makes a wrong guess here harmless in both directions: a
- * European we fail to recognise stays denied, and an Israeli we ask needlessly
- * sees one extra prompt. The zones are the EEA plus the United Kingdom.
- */
-const CONSENT_REQUIRED_TIME_ZONES = [
-  'Africa/Ceuta',
-  'Asia/Famagusta',
-  'Asia/Nicosia',
-  'Atlantic/Azores',
-  'Atlantic/Canary',
-  'Atlantic/Madeira',
-  'Atlantic/Reykjavik',
-  'Europe/Amsterdam',
-  'Europe/Athens',
-  'Europe/Berlin',
-  'Europe/Bratislava',
-  'Europe/Brussels',
-  'Europe/Bucharest',
-  'Europe/Budapest',
-  'Europe/Busingen',
-  'Europe/Copenhagen',
-  'Europe/Dublin',
-  'Europe/Helsinki',
-  'Europe/Lisbon',
-  'Europe/Ljubljana',
-  'Europe/London',
-  'Europe/Luxembourg',
-  'Europe/Madrid',
-  'Europe/Malta',
-  'Europe/Oslo',
-  'Europe/Paris',
-  'Europe/Prague',
-  'Europe/Riga',
-  'Europe/Rome',
-  'Europe/Sofia',
-  'Europe/Stockholm',
-  'Europe/Tallinn',
-  'Europe/Vaduz',
-  'Europe/Vienna',
-  'Europe/Vilnius',
-  'Europe/Warsaw',
-  'Europe/Zagreb',
-];
 
 function readDecision() {
   try {
@@ -68,20 +28,8 @@ function readDecision() {
   }
 }
 
-function isConsentRequired() {
-  try {
-    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return CONSENT_REQUIRED_TIME_ZONES.indexOf(timeZone) !== -1;
-  } catch (error) {
-    // Without a readable time zone we cannot place the visitor. Staying quiet
-    // leaves them on the defaults, which is the safe half of the trade: a
-    // European keeps their storage denied, they just cannot lift it.
-    return false;
-  }
-}
-
 function shouldAsk() {
-  return !readDecision() && isConsentRequired();
+  return !readDecision();
 }
 
 /**
@@ -106,7 +54,6 @@ function decide(decision) {
 
 export const consentService = {
   readDecision,
-  isConsentRequired,
   shouldAsk,
   decide,
 };


### PR DESCRIPTION
## What

The banner was gated on a time zone allowlist, so only EEA and UK visitors were ever asked. Israeli visitors — nearly all of the traffic — were tracked without being told and with no way to refuse. Every visitor is now asked.

The difference between the two regimes stays where it belongs, in the tag snippet, and is unchanged by this PR:

| | Default storage | What the banner does |
| --- | --- | --- |
| EEA / UK | denied | switches tracking **on** — prior opt-in, as ePrivacy requires |
| Everywhere else | granted | notice plus a genuine way to **opt out** |

## Why the allowlist is gone rather than inverted

Google already resolves the region by IP through the `region` list, which a browser cannot do. Keeping a second, weaker answer to the same question in the client bought nothing once the banner is shown to everyone, so the 37-entry table and `isConsentRequired` are deleted. `shouldAsk` is now just "have they answered yet".

A side effect worth having: verifying the banner no longer needs a temporary build with a faked time zone.

## Verification

Ran against the production build, from an `Asia/Jerusalem` browser.

| Scenario | Result |
| --- | --- |
| First visit, no decision | banner shown, with the privacy policy link |
| "דחייה" | `localStorage='denied'`, banner gone, `consent update` with all four parameters denied |
| Reload | banner does not return, answer persists |

The EEA path is unchanged and was verified in #46.

## Note

This follows a reading of the law, not legal advice: ePrivacy and GDPR settle the European case, while the Israeli position rests on the notice and informed-consent duties in the Privacy Protection Law as tightened by Amendment 13. Worth a lawyer's confirmation, along with the other privacy follow-ups listed in #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
