### PR TITLE
fix(mobile): horizontal overflow on home and checkout, and rebuild the mobile cart

### DIFF
--- a/src/cmps/Cart/Cart.jsx
+++ b/src/cmps/Cart/Cart.jsx
@@ -4,43 +4,138 @@ import IconButton from '@mui/material/IconButton';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import Typography from '@mui/material/Typography';
-import Grid from '@mui/material/Grid';
 import Button from '../Controls/Button';
 import { cartService } from '../../services/cartService';
 import { eventBus } from '../../services/event-bus';
 import { makeStyles } from '@mui/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
+import { colors, fonts, radii } from '../../styles/designTokens';
 
+/**
+ * On a phone the cart fills the screen, so it is laid out as a sheet: a pinned
+ * header, a scrolling list, and a pinned footer carrying the total and the call
+ * to action. Header and footer stick rather than sitting in a wrapper, because
+ * MUI renders these children straight into its MenuList <ul> and an extra <div>
+ * there would be invalid markup.
+ */
 const useStyles = makeStyles(() => ({
   paper: {
     top: '80px!important',
     height: '80%',
     width: '25%',
+    minWidth: 320,
+    borderRadius: radii.lg,
+    // MUI v5 injects its emotion styles after this JSS sheet, so a plain
+    // declaration here loses to .MuiPopover-paper on equal specificity. Only
+    // !important reaches the element — hence the shouting on every box
+    // property that has to beat a MUI default.
     '@media (max-width: 700px)': {
-      position: 'fixed',
+      position: 'fixed!important',
       top: '0!important',
-      bottom: '0',
-      right: '0',
+      bottom: '0!important',
+      right: '0!important',
       left: '0!important',
-      minWidth: '100% !important',
-      minHeight: '100% !important',
-      maxHeight: '16px',
+      width: '100%!important',
+      minWidth: '100%!important',
+      maxWidth: '100%!important',
+      height: '100%!important',
+      maxHeight: '100%!important',
+      borderRadius: '0!important',
     },
   },
-  containerText: {
-    display: 'flex !important',
-    justifyContent: 'flex-start !important',
-    alignItems: 'center !important',
-    textAlign: 'right !important',
+  list: {
+    padding: '0!important',
+    // Fill the sheet so the footer can be pushed to the bottom edge instead of
+    // floating directly under a short list.
+    minHeight: '100%',
+    display: 'flex',
     flexDirection: 'column',
   },
-  textCartProduct: {
+  header: {
+    position: 'sticky',
+    top: 0,
+    zIndex: 2,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    padding: '12px 16px',
+    background: colors.surface,
+    borderBottom: `1px solid ${colors.border}`,
+  },
+  title: {
+    fontFamily: fonts.display,
+    fontSize: 20,
+    color: colors.text,
+  },
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    padding: '14px 16px',
+    borderBottom: `1px solid ${colors.border}`,
+    whiteSpace: 'normal',
+  },
+  itemMain: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  },
+  itemName: {
+    fontWeight: 700,
+    fontSize: 15,
+    color: colors.text,
+    // Long dish names must wrap instead of stretching the row, which is what
+    // pushed the buttons out of alignment before.
+    overflowWrap: 'anywhere',
+  },
+  itemSize: {
+    fontSize: 13,
+    color: colors.textMuted,
+  },
+  itemSide: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    flexShrink: 0,
+  },
+  itemPrice: {
+    fontWeight: 700,
+    fontSize: 15,
+    color: colors.text,
+  },
+  empty: {
+    padding: '32px 16px',
+    textAlign: 'center',
+    color: colors.textMuted,
+  },
+  footer: {
+    // `auto` rather than sticky: the list is a flex column, so this drops the
+    // footer to the bottom edge whether the cart holds one item or twenty.
+    marginTop: 'auto',
+    position: 'sticky',
+    bottom: 0,
+    zIndex: 2,
     display: 'block',
-    textOverflow: 'ellipsis',
-    wordWrap: 'break-word',
-    lineHeight: '1.8em',
-    whiteSpace: 'pre-wrap',
+    padding: '14px 16px',
+    background: colors.surface,
+    borderTop: `1px solid ${colors.border}`,
+  },
+  totalRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  totalLabel: {
+    fontSize: 15,
+    color: colors.textSoft,
+  },
+  totalValue: {
+    fontFamily: fonts.display,
+    fontSize: 22,
+    color: colors.greenInk,
   },
 }));
 
@@ -51,8 +146,7 @@ export const Cart = ({
   setCart,
   setIsOpenMenu,
 }) => {
-  const matches = useMediaQuery('(min-width:700px)');
-  const classes = useStyles(matches);
+  const classes = useStyles();
   const history = useHistory();
   const [cartComp, setCartComp] = useState();
   useEffect(() => {
@@ -87,45 +181,52 @@ export const Cart = ({
     }
   };
 
+  const items = (cartComp || []).filter((order) => order.product);
+  const total = items.reduce(
+    (sum, order) => sum + Number(order.priceToShow || 0),
+    0
+  );
+
   return (
     <Menu
-      classes={{ paper: classes.paper }}
+      classes={{ paper: classes.paper, list: classes.list }}
       anchorEl={anchorEl}
       keepMounted
       open={Boolean(anchorEl)}
       onClose={handleClose}
     >
-      <IconButton
-        style={{ marginRight: '1rem' }}
-        edge="start"
-        onClick={handleClose}
-      >
-        <CloseOutlined />
-      </IconButton>
-      {cartComp && cartComp.length ? (
-        cartComp.map((order) => {
-          if (!order.product) return null;
+      <li role="presentation" className={classes.header}>
+        <span className={classes.title}>העגלה</span>
+        <IconButton aria-label="סגירת העגלה" onClick={handleClose} size="small">
+          <CloseOutlined />
+        </IconButton>
+      </li>
 
-          return (
-            <MenuItem
-              role="presentation"
-              key={order._id}
-              classes={{ root: classes.containerText }}
-            >
-              <Typography className={classes.textCartProduct}>
-                מוצר: {order.product.displayName}
-              </Typography>
-              <Typography className={classes.textCartProduct}>
-                כמות: {sizeText(order)}
-              </Typography>
-              <Typography className={classes.textCartProduct}>
-                מחיר: {order.priceToShow}
+      {items.length ? (
+        items.map((order) => (
+          <MenuItem
+            role="presentation"
+            disableRipple
+            key={order._id}
+            classes={{ root: classes.item }}
+          >
+            <span className={classes.itemMain}>
+              <span className={classes.itemName}>
+                {order.product.displayName}
+              </span>
+              <span className={classes.itemSize}>{sizeText(order)}</span>
+            </span>
+            <span className={classes.itemSide}>
+              <span className={classes.itemPrice}>
+                {order.priceToShow}
                 {shekel}
-              </Typography>
+              </span>
               <Button
                 text="הסר"
+                size="small"
+                variant="text"
                 tabIndex={0}
-                aria-label="הסר מהעגלה"
+                aria-label={`הסרת ${order.product.displayName} מהעגלה`}
                 onClick={() => removeFromCart(order._id)}
                 onKeyPress={(e) => {
                   if (e.key === 'Enter') {
@@ -133,22 +234,26 @@ export const Cart = ({
                   }
                 }}
               />
-            </MenuItem>
-          );
-        })
+            </span>
+          </MenuItem>
+        ))
       ) : (
-        <Grid container mr={2}>
-          <Typography>אין מוצרים בעגלה</Typography>
-        </Grid>
+        <li role="presentation" className={classes.empty}>
+          אין מוצרים בעגלה
+        </li>
       )}
 
-      {cartComp && cartComp.length ? (
-        <Button
-          style={{ marginRight: '1rem' }}
-          text="להזמנה"
-          aria-label="להזמנה"
-          onClick={checkOutOrder}
-        />
+      {items.length ? (
+        <li role="presentation" className={classes.footer}>
+          <span className={classes.totalRow}>
+            <span className={classes.totalLabel}>סה״כ</span>
+            <span className={classes.totalValue}>
+              {total}
+              {shekel}
+            </span>
+          </span>
+          <Button fullWidth text="להזמנה" aria-label="מעבר להזמנה" onClick={checkOutOrder} />
+        </li>
       ) : null}
     </Menu>
   );

--- a/src/pages/CheckoutOrder/CheckoutOrder.jsx
+++ b/src/pages/CheckoutOrder/CheckoutOrder.jsx
@@ -159,6 +159,10 @@ const useStyles = makeStyles({
     flex: 'none',
     overflow: 'hidden',
     display: 'block',
+    // Anchors the absolutely positioned blur placeholder cloudinary-react
+    // overlays. Without it the placeholder sizes itself against the viewport
+    // and spills out of the row, widening the page on a phone.
+    position: 'relative',
     '& img': {
       width: '100%',
       height: '100%',

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -364,6 +364,13 @@ const useStyles = makeStyles({
     borderRadius: '50%',
     margin: '0 auto 10px',
     overflow: 'hidden',
+    // cloudinary-react overlays its blur placeholder as an absolutely
+    // positioned <img>. Without a positioned ancestor that <img> resolves its
+    // 100% against the viewport instead of this circle, so it rendered at the
+    // full 375x812 and dragged the whole page sideways on a phone. `overflow`
+    // alone cannot clip it, because clipping only reaches descendants whose
+    // containing block sits inside the clipper.
+    position: 'relative',
     '& img': { width: '100%', height: '100%', objectFit: 'cover' },
   },
   catLabel: { fontWeight: 700, fontSize: 15, color: colors.text },


### PR DESCRIPTION
Full mobile layout QA, prompted by three screenshots of a phone. They turned out to be two bugs, and the sweep found a third that was not photographed.

## Horizontal overflow — home page and checkout

The page measured 648px wide inside a 375px viewport.

`cloudinary-react` overlays its blur placeholder as an absolutely positioned `<img>`. Neither the category circle on the home page nor the line thumbnail at checkout was itself positioned, so that `<img>` resolved its `100%` against the viewport — a 375×812 image inside a 60px circle. On a phone it showed as the announcement bar and header cut off on one side with a gutter on the other.

`overflow: hidden` could not contain it: clipping only reaches descendants whose containing block sits inside the clipper. Hence `position: relative` on the wrappers rather than more overflow rules.

Checkout had the same defect at 35px, not visible in the screenshots.

## Mobile cart

The paper carried `maxHeight: 16px` fighting `minHeight: 100%`, and the checkout button sat loose after the list with no container, so it landed wherever it fell rather than beside the remove button — scattered controls above a screen of empty white.

Rebuilt as a sheet: pinned header with title and close, scrolling list where each line puts name and size on one side and price and remove on the other, and a pinned footer carrying the total — which the cart never showed — above a full-width call to action.

## A trap worth knowing about

MUI v5 injects its emotion styles **after** the `makeStyles` JSS sheet. On equal specificity the later rule wins, so half the cart rules disappeared silently: `position`, `width`, `height`. Only the `!important` ones landed, which is why the original author already shouted `minWidth` and `minHeight`.

Any rule in these files that has to beat a MUI default needs `!important` — otherwise it does not fail, it just never happens.

## Verification

Measured `scrollWidth` against `clientWidth` on the production build.

| Screen / state | 375px | 320px |
| --- | --- | --- |
| Home | 273 → **0** | 0 |
| Checkout | 35 → **0** | 0 |
| Menu (142 dishes) | 0 | 0 |
| About · Contact · Privacy · Accessibility | 0 | — |
| Mobile drawer · quick-add modal · cart | 0 | 0 |

Run against the live API so the pages carried real content.

## Not fixed here

- The broken fish thumbnail in the third screenshot is a **data** problem, not layout. Category 7 stores `imgUrl` as the plain text `"פילה מושט בעשבי תיבול"` while every other category stores a real public_id such as `כבש_nmmk7a`. Confirmed against Cloudinary: the working id returns 200, this one returns 404. Tracked separately, since it is a production data change.
- `cmps/ProductCard` and `cmps/CategoryCard` are dead code — imported only by their own `index.js`. The live components are under `cmps/design/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
